### PR TITLE
Add `into_values()` method to `Static{Copy,}Map`

### DIFF
--- a/linearize-tests/src/tests/copy_map.rs
+++ b/linearize-tests/src/tests/copy_map.rs
@@ -141,6 +141,68 @@ fn index() {
 }
 
 #[test]
+fn into_values() {
+    let map: StaticCopyMap<_, u8> = static_copy_map! {
+        false => 0,
+        true => 1,
+    };
+    {
+        let mut iter = map.into_values();
+        assert_eq!(iter.next(), Some(0));
+        assert_eq!(iter.next(), Some(1));
+        assert_eq!(iter.next(), None);
+    }
+    {
+        let mut iter = map.into_values();
+        assert_eq!(iter.next_back(), Some(1));
+        assert_eq!(iter.next_back(), Some(0));
+        assert_eq!(iter.next_back(), None);
+    }
+    {
+        let iter = map.into_values();
+        assert_eq!(iter.size_hint(), (2, Some(2)));
+    }
+    {
+        let iter = map.into_values();
+        assert_eq!(iter.count(), 2);
+    }
+    {
+        let iter = map.into_values();
+        assert_eq!(iter.last(), Some(1));
+    }
+    {
+        let mut iter = map.into_values();
+        assert_eq!(iter.nth(0), Some(0));
+        assert_eq!(iter.nth(0), Some(1));
+        assert_eq!(iter.nth(0), None);
+    }
+    {
+        let mut iter = map.into_values();
+        assert_eq!(iter.nth(1), Some(1));
+        assert_eq!(iter.nth(0), None);
+    }
+    {
+        let mut iter = map.into_values();
+        assert_eq!(iter.nth(2), None);
+    }
+    {
+        let mut iter = map.into_values();
+        assert_eq!(iter.nth_back(0), Some(1));
+        assert_eq!(iter.nth_back(0), Some(0));
+        assert_eq!(iter.nth_back(0), None);
+    }
+    {
+        let mut iter = map.into_values();
+        assert_eq!(iter.nth_back(1), Some(0));
+        assert_eq!(iter.nth_back(0), None);
+    }
+    {
+        let mut iter = map.into_values();
+        assert_eq!(iter.nth_back(2), None);
+    }
+}
+
+#[test]
 fn as_ref() {
     let mut map: StaticCopyMap<_, u8> = static_copy_map! {
         false => 0,

--- a/linearize-tests/src/tests/map.rs
+++ b/linearize-tests/src/tests/map.rs
@@ -450,6 +450,68 @@ fn into_iter() {
 }
 
 #[test]
+fn into_values() {
+    let map: StaticMap<_, u8> = static_map! {
+        false => 0,
+        true => 1,
+    };
+    {
+        let mut iter = map.clone().into_values();
+        assert_eq!(iter.next(), Some(0));
+        assert_eq!(iter.next(), Some(1));
+        assert_eq!(iter.next(), None);
+    }
+    {
+        let mut iter = map.clone().into_values();
+        assert_eq!(iter.next_back(), Some(1));
+        assert_eq!(iter.next_back(), Some(0));
+        assert_eq!(iter.next_back(), None);
+    }
+    {
+        let iter = map.clone().into_values();
+        assert_eq!(iter.size_hint(), (2, Some(2)));
+    }
+    {
+        let iter = map.clone().into_values();
+        assert_eq!(iter.count(), 2);
+    }
+    {
+        let iter = map.clone().into_values();
+        assert_eq!(iter.last(), Some(1));
+    }
+    {
+        let mut iter = map.clone().into_values();
+        assert_eq!(iter.nth(0), Some(0));
+        assert_eq!(iter.nth(0), Some(1));
+        assert_eq!(iter.nth(0), None);
+    }
+    {
+        let mut iter = map.clone().into_values();
+        assert_eq!(iter.nth(1), Some(1));
+        assert_eq!(iter.nth(0), None);
+    }
+    {
+        let mut iter = map.clone().into_values();
+        assert_eq!(iter.nth(2), None);
+    }
+    {
+        let mut iter = map.clone().into_values();
+        assert_eq!(iter.nth_back(0), Some(1));
+        assert_eq!(iter.nth_back(0), Some(0));
+        assert_eq!(iter.nth_back(0), None);
+    }
+    {
+        let mut iter = map.clone().into_values();
+        assert_eq!(iter.nth_back(1), Some(0));
+        assert_eq!(iter.nth_back(0), None);
+    }
+    {
+        let mut iter = map.clone().into_values();
+        assert_eq!(iter.nth_back(2), None);
+    }
+}
+
+#[test]
 fn deref() {
     let mut map: StaticMap<_, u8> = static_map! {
         false => 0,

--- a/linearize/src/copy_map.rs
+++ b/linearize/src/copy_map.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         iter::{Iter, IterMut},
-        map::iters::IntoIter,
+        map::iters::{IntoIter, IntoValues},
         storage::CopyStorage,
         Linearize, Linearized, StaticMap,
     },
@@ -239,8 +239,11 @@ where
     /// assert_eq!(iter.next(), Some(1));
     /// assert_eq!(iter.next(), None);
     /// ```   
-    pub fn into_values(self) -> <L::CopyStorage<T> as IntoIterator>::IntoIter {
-        self.0.into_iter()
+    pub fn into_values(self) -> IntoValues<L, T>
+    where
+        L: Sized,
+    {
+        self.into_static_map().into_values()
     }
 }
 

--- a/linearize/src/copy_map.rs
+++ b/linearize/src/copy_map.rs
@@ -223,6 +223,25 @@ where
     {
         self.into_static_map().map_values(map).into_copy()
     }
+
+    /// Consumes the map and returns an iterator over the values.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use linearize::{static_copy_map, StaticCopyMap};
+    /// let mut map: StaticCopyMap<_, u8> = static_copy_map! {
+    ///     false => 0,
+    ///     true => 1,
+    /// };
+    /// let mut iter = map.into_values();
+    /// assert_eq!(iter.next(), Some(0));
+    /// assert_eq!(iter.next(), Some(1));
+    /// assert_eq!(iter.next(), None);
+    /// ```   
+    pub fn into_values(self) -> <L::CopyStorage<T> as IntoIterator>::IntoIter {
+        self.0.into_iter()
+    }
 }
 
 impl<L, T> Deref for StaticCopyMap<L, T>

--- a/linearize/src/lib.rs
+++ b/linearize/src/lib.rs
@@ -115,13 +115,13 @@ pub unsafe trait Linearize {
     ///
     /// This type exists due to a limitation of the rust type system. In a future version
     /// of this crate, all uses of it will be replaced by `[T; Self::LENGTH]`.
-    type Storage<T>: Storage<Self, T>;
+    type Storage<T>: Storage<Self, T> + IntoIterator<Item = T>;
 
     /// `[T; Self::LENGTH]`
     ///
     /// This type exists due to a limitation of the rust type system. In a future version
     /// of this crate, all uses of it will be replaced by `[T; Self::LENGTH]`.
-    type CopyStorage<T>: CopyStorage<Self, T>
+    type CopyStorage<T>: CopyStorage<Self, T> + IntoIterator<Item = T>
     where
         T: Copy;
 

--- a/linearize/src/lib.rs
+++ b/linearize/src/lib.rs
@@ -115,13 +115,13 @@ pub unsafe trait Linearize {
     ///
     /// This type exists due to a limitation of the rust type system. In a future version
     /// of this crate, all uses of it will be replaced by `[T; Self::LENGTH]`.
-    type Storage<T>: Storage<Self, T> + IntoIterator<Item = T>;
+    type Storage<T>: Storage<Self, T>;
 
     /// `[T; Self::LENGTH]`
     ///
     /// This type exists due to a limitation of the rust type system. In a future version
     /// of this crate, all uses of it will be replaced by `[T; Self::LENGTH]`.
-    type CopyStorage<T>: CopyStorage<Self, T> + IntoIterator<Item = T>
+    type CopyStorage<T>: CopyStorage<Self, T>
     where
         T: Copy;
 

--- a/linearize/src/map.rs
+++ b/linearize/src/map.rs
@@ -543,6 +543,25 @@ where
     {
         IterMut::new(&mut self.0)
     }
+
+    /// Consumes the map and returns an iterator over the values.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use linearize::{static_map, StaticMap};
+    /// let mut map: StaticMap<_, u8> = static_map! {
+    ///     false => 0,
+    ///     true => 1,
+    /// };
+    /// let mut iter = map.into_values();
+    /// assert_eq!(iter.next(), Some(0));
+    /// assert_eq!(iter.next(), Some(1));
+    /// assert_eq!(iter.next(), None);
+    /// ```   
+    pub fn into_values(self) -> <L::Storage<T> as IntoIterator>::IntoIter {
+        self.0.into_iter()
+    }
 }
 
 impl<L, T> Deref for StaticMap<L, T>

--- a/linearize/src/map.rs
+++ b/linearize/src/map.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         copy_map::StaticCopyMap,
-        map::iters::{IntoIter, Iter, IterMut},
+        map::iters::{IntoIter, IntoValues, Iter, IterMut},
         storage::Storage,
         variants::Variants,
         Linearize, LinearizeExt, Linearized,
@@ -559,8 +559,11 @@ where
     /// assert_eq!(iter.next(), Some(1));
     /// assert_eq!(iter.next(), None);
     /// ```   
-    pub fn into_values(self) -> <L::Storage<T> as IntoIterator>::IntoIter {
-        self.0.into_iter()
+    pub fn into_values(self) -> IntoValues<L, T>
+    where
+        L: Sized,
+    {
+        IntoValues::new(self.0)
     }
 }
 

--- a/linearize/src/map/iters.rs
+++ b/linearize/src/map/iters.rs
@@ -290,3 +290,70 @@ where
         })
     }
 }
+
+/// A consuming iterator over the keys and values of a [`StaticMap`].
+pub struct IntoValues<L, T>
+where
+    L: Linearize,
+{
+    iter: <<L as Linearize>::Storage<T> as IntoIterator>::IntoIter,
+}
+
+impl<L, T> IntoValues<L, T>
+where
+    L: Linearize,
+{
+    pub(super) fn new(storage: L::Storage<T>) -> Self {
+        Self {
+            iter: <L::Storage<T> as IntoIterator>::into_iter(storage),
+        }
+    }
+}
+
+impl<L, T> Iterator for IntoValues<L, T>
+where
+    L: Linearize,
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+
+    fn count(self) -> usize
+    where
+        Self: Sized,
+    {
+        self.iter.count()
+    }
+
+    fn last(self) -> Option<Self::Item>
+    where
+        Self: Sized,
+    {
+        self.iter.last()
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter.nth(n)
+    }
+}
+
+impl<L, T> ExactSizeIterator for IntoValues<L, T> where L: Linearize {}
+
+impl<L, T> DoubleEndedIterator for IntoValues<L, T>
+where
+    L: Linearize,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back()
+    }
+
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter.nth_back(n)
+    }
+}


### PR DESCRIPTION
Fixes #3.