### PR TITLE
Add `try_from_iter` to fallibly collect without a `Default` bound

### DIFF
--- a/linearize-tests/src/tests/copy_map.rs
+++ b/linearize-tests/src/tests/copy_map.rs
@@ -427,6 +427,23 @@ fn from_iterator() {
 }
 
 #[test]
+fn try_from_iterator() {
+    let array: [(bool, u8); 0] = [];
+    let map: StaticMap<bool, Option<u8>> = StaticMap::try_from_iter(array).unwrap_err();
+    assert_eq!(map[false], None);
+    assert_eq!(map[true], None);
+    let map: StaticMap<bool, Option<u8>> = StaticMap::try_from_iter([(false, 1)]).unwrap_err();
+    assert_eq!(map[false], Some(1));
+    assert_eq!(map[true], None);
+    let map: StaticMap<bool, Option<u8>> = StaticMap::try_from_iter([(true, 2)]).unwrap_err();
+    assert_eq!(map[false], None);
+    assert_eq!(map[true], Some(2));
+    let map: StaticMap<bool, u8> = StaticMap::try_from_iter([(false, 1), (true, 2)]).unwrap();
+    assert_eq!(map[false], 1);
+    assert_eq!(map[true], 2);
+}
+
+#[test]
 fn type_inference() {
     #[derive(Linearize)]
     enum X {

--- a/linearize-tests/src/tests/map.rs
+++ b/linearize-tests/src/tests/map.rs
@@ -774,3 +774,20 @@ fn from_iterator() {
     assert_eq!(map[false], 1);
     assert_eq!(map[true], 2);
 }
+
+#[test]
+fn try_from_iterator() {
+    let array: [(bool, u8); 0] = [];
+    let map: StaticMap<bool, Option<u8>> = StaticMap::try_from_iter(array).unwrap_err();
+    assert_eq!(map[false], None);
+    assert_eq!(map[true], None);
+    let map: StaticMap<bool, Option<u8>> = StaticMap::try_from_iter([(false, 1)]).unwrap_err();
+    assert_eq!(map[false], Some(1));
+    assert_eq!(map[true], None);
+    let map: StaticMap<bool, Option<u8>> = StaticMap::try_from_iter([(true, 2)]).unwrap_err();
+    assert_eq!(map[false], None);
+    assert_eq!(map[true], Some(2));
+    let map: StaticMap<bool, u8> = StaticMap::try_from_iter([(false, 1), (true, 2)]).unwrap();
+    assert_eq!(map[false], 1);
+    assert_eq!(map[true], 2);
+}

--- a/linearize/src/copy_map.rs
+++ b/linearize/src/copy_map.rs
@@ -112,8 +112,8 @@ where
     /// assert_eq!(map, Err(StaticCopyMap([Some(0), None])));
     /// ```
     #[inline]
-    pub fn try_from_iter<I: IntoIterator<Item = (L, T)>>(
-        iter: I,
+    pub fn try_from_iter(
+        iter: impl IntoIterator<Item = (L, T)>,
     ) -> Result<Self, StaticCopyMap<L, Option<T>>>
     where
         L: Sized,

--- a/linearize/src/copy_map.rs
+++ b/linearize/src/copy_map.rs
@@ -98,6 +98,32 @@ where
         }
     }
 
+    /// Fallibly collects an iterator into a map. Returns Err if some key is not produced by
+    /// the iterator.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use linearize::StaticCopyMap;
+    /// let map = StaticCopyMap::try_from_iter([(false, 0), (true, 1)]);
+    /// assert_eq!(map, Ok(StaticCopyMap([0, 1])));
+    ///
+    /// let map = StaticCopyMap::try_from_iter([(false, 0)]);
+    /// assert_eq!(map, Err(StaticCopyMap([Some(0), None])));
+    /// ```
+    #[inline]
+    pub fn try_from_iter<I: IntoIterator<Item = (L, T)>>(
+        iter: I,
+    ) -> Result<Self, StaticCopyMap<L, Option<T>>>
+    where
+        L: Sized,
+    {
+        match StaticMap::try_from_iter(iter) {
+            Ok(map) => Ok(map.into_copy()),
+            Err(map) => Err(map.into_copy()),
+        }
+    }
+
     /// Converts this map to a [StaticMap].
     ///
     /// This is a zero-cost conversion.

--- a/linearize/src/map.rs
+++ b/linearize/src/map.rs
@@ -230,6 +230,36 @@ where
         }
     }
 
+    /// Fallibly collects an iterator into a map. Returns Err if some key is not produced by
+    /// the iterator.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use linearize::StaticMap;
+    /// let map = StaticMap::try_from_iter([(false, 0), (true, 1)]);
+    /// assert_eq!(map, Ok(StaticMap([0, 1])));
+    ///
+    /// let map = StaticMap::try_from_iter([(false, 0)]);
+    /// assert_eq!(map, Err(StaticMap([Some(0), None])));
+    /// ```
+    #[inline]
+    pub fn try_from_iter<I: IntoIterator<Item = (L, T)>>(
+        iter: I,
+    ) -> Result<Self, StaticMap<L, Option<T>>>
+    where
+        L: Sized,
+    {
+        let mut res = StaticMap::<L, Option<T>>::default();
+        for (k, v) in iter {
+            res[k] = Some(v);
+        }
+        if res.values().any(|v| v.is_none()) {
+            return Err(res);
+        }
+        Ok(res.map_values(|v| v.unwrap()))
+    }
+
     /// Converts this map to a [StaticCopyMap].
     ///
     /// This is a zero-cost conversion.

--- a/linearize/src/map.rs
+++ b/linearize/src/map.rs
@@ -244,8 +244,8 @@ where
     /// assert_eq!(map, Err(StaticMap([Some(0), None])));
     /// ```
     #[inline]
-    pub fn try_from_iter<I: IntoIterator<Item = (L, T)>>(
-        iter: I,
+    pub fn try_from_iter(
+        iter: impl IntoIterator<Item = (L, T)>,
     ) -> Result<Self, StaticMap<L, Option<T>>>
     where
         L: Sized,


### PR DESCRIPTION
Fixes #4. 

Should the difference from the FromIterator implementation be explained in the documentation? 

Should the examples use a type that does not implement `Default`? If so, is `Result` a good type for that or is there something more obvious?