### PR TITLE
Re-export `IntoValues`

### DIFF
--- a/linearize/src/lib.rs
+++ b/linearize/src/lib.rs
@@ -201,7 +201,7 @@ pub mod iter {
     //!
     //! This module exists only to keep the top-level namespace clean.
     pub use crate::{
-        map::iters::{IntoIter, Iter, IterMut},
+        map::iters::{IntoIter, IntoValues, Iter, IterMut},
         variants::Variants,
     };
 }


### PR DESCRIPTION
I missed this in #5. I didn't even realize it was possible for a `pub fn` to have a non-public return type.