### PR TITLE
Add `postcard` and `defmt` derives gated by feature flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,6 +60,7 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "linearize-derive",
+ "postcard",
  "rand 0.8.5",
  "rand 0.9.2",
  "serde",
@@ -74,6 +84,7 @@ dependencies = [
  "arbitrary",
  "bytemuck",
  "linearize",
+ "postcard",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -86,6 +97,28 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "postcard-derive",
+ "serde",
+]
+
+[[package]]
+name = "postcard-derive"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0232bd009a197ceec9cc881ba46f727fcd8060a2d8d6a9dde7a69030a6fe2bb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -223,6 +256,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bytemuck"
 version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,6 +31,38 @@ name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+dependencies = [
+ "bitflags",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
  "thiserror",
 ]
@@ -59,6 +97,7 @@ dependencies = [
  "arbitrary",
  "bytemuck",
  "cfg-if",
+ "defmt",
  "linearize-derive",
  "postcard",
  "rand 0.8.5",
@@ -83,6 +122,7 @@ version = "0.1.0"
 dependencies = [
  "arbitrary",
  "bytemuck",
+ "defmt",
  "linearize",
  "postcard",
  "rand 0.8.5",
@@ -127,6 +167,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/linearize-tests/Cargo.toml
+++ b/linearize-tests/Cargo.toml
@@ -13,6 +13,7 @@ rand = "0.8.5"
 bytemuck = "1.19.0"
 arbitrary = "1.4.1"
 postcard = { version = "1", default-features = false, features = ["experimental-derive"] }
+defmt = "1"
 
 [build-dependencies]
 version_check = "0.9.5"

--- a/linearize-tests/Cargo.toml
+++ b/linearize-tests/Cargo.toml
@@ -12,6 +12,7 @@ serde_json = "1.0.133"
 rand = "0.8.5"
 bytemuck = "1.19.0"
 arbitrary = "1.4.1"
+postcard = { version = "1", default-features = false, features = ["experimental-derive"] }
 
 [build-dependencies]
 version_check = "0.9.5"

--- a/linearize-tests/src/tests.rs
+++ b/linearize-tests/src/tests.rs
@@ -9,6 +9,7 @@ mod linearize_ext;
 mod linearized;
 mod r#macro;
 mod map;
+mod postcard;
 mod rand;
 mod serde;
 mod variants;

--- a/linearize-tests/src/tests.rs
+++ b/linearize-tests/src/tests.rs
@@ -4,6 +4,7 @@ mod arbitrary;
 mod bytemuck;
 mod copy_map;
 mod core_addressing;
+mod defmt;
 mod derive;
 mod linearize_ext;
 mod linearized;

--- a/linearize-tests/src/tests/defmt.rs
+++ b/linearize-tests/src/tests/defmt.rs
@@ -1,0 +1,16 @@
+use {
+    defmt::Format,
+    linearize::{StaticCopyMap, StaticMap},
+};
+
+const _: () = {
+    #[allow(unconditional_recursion)]
+    fn _forward<T: Format>() {
+        _forward::<StaticMap<(), T>>();
+    }
+
+    #[allow(unconditional_recursion)]
+    fn _forward_copy<T: Format + Copy>() {
+        _forward_copy::<StaticCopyMap<(), T>>();
+    }
+};

--- a/linearize-tests/src/tests/postcard.rs
+++ b/linearize-tests/src/tests/postcard.rs
@@ -1,0 +1,33 @@
+use {
+    linearize::{static_map, StaticCopyMap, StaticMap},
+    postcard::experimental::max_size::MaxSize,
+};
+
+#[test]
+fn max_size_is_upper_bound() {
+    // Small map: bool keys (2 entries)
+    let map: StaticMap<bool, u8> = static_map! {
+        false => u8::MAX,
+        true => u8::MAX,
+    };
+    let mut buf = [0u8; <StaticMap<bool, u8>>::POSTCARD_MAX_SIZE];
+    postcard::to_slice(&map, &mut buf).unwrap();
+
+    // Medium map with larger values
+    let map: StaticMap<bool, u16> = static_map! {
+        false => u16::MAX,
+        true => u16::MAX,
+    };
+    let mut buf = [0u8; <StaticMap<bool, u16>>::POSTCARD_MAX_SIZE];
+    postcard::to_slice(&map, &mut buf).unwrap();
+
+    // Large map: u8 keys (256 entries), max values
+    let map = StaticMap::<u8, u8>::from_fn(|_| u8::MAX);
+    let mut buf = [0u8; <StaticMap<u8, u8>>::POSTCARD_MAX_SIZE];
+    postcard::to_slice(&map, &mut buf).unwrap();
+
+    // CopyMap variant
+    let map: StaticCopyMap<bool, u8> = StaticCopyMap::from_fn(|_| u8::MAX);
+    let mut buf = [0u8; <StaticCopyMap<bool, u8>>::POSTCARD_MAX_SIZE];
+    postcard::to_slice(&map, &mut buf).unwrap();
+}

--- a/linearize/Cargo.toml
+++ b/linearize/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.83.0"
 
 [features]
 default = ["std"]
-all = ["std", "alloc", "derive", "serde-1", "arbitrary-1", "bytemuck-1", "rand-0_8", "rand-0_9"]
+all = ["std", "alloc", "derive", "serde-1", "arbitrary-1", "bytemuck-1", "rand-0_8", "rand-0_9", "postcard-experimental-1"]
 std = ["alloc"]
 alloc = ["rand-0_8?/alloc", "rand-0_9?/alloc"]
 derive = ["dep:linearize-derive"]
@@ -22,6 +22,7 @@ arbitrary-1 = ["dep:arbitrary-1"]
 bytemuck-1 = ["dep:bytemuck-1"]
 rand-0_8 = ["dep:rand-0_8"]
 rand-0_9 = ["dep:rand-0_9"]
+postcard-experimental-1 = ["dep:postcard-1"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -34,6 +35,7 @@ arbitrary-1 = { package = "arbitrary", version = "1.4", default-features = false
 bytemuck-1 = { package = "bytemuck", version = "1.9", default-features = false, optional = true }
 rand-0_8 = { package = "rand", version = "0.8.3", default-features = false, optional = true }
 rand-0_9 = { package = "rand", version = "0.9", default-features = false, optional = true }
+postcard-1 = { package = "postcard", version = "1", default-features = false, features = ["experimental-derive"], optional = true }
 
 [build-dependencies]
 version_check = "0.9.5"

--- a/linearize/Cargo.toml
+++ b/linearize/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.83.0"
 
 [features]
 default = ["std"]
-all = ["std", "alloc", "derive", "serde-1", "arbitrary-1", "bytemuck-1", "rand-0_8", "rand-0_9", "postcard-experimental-1"]
+all = ["std", "alloc", "derive", "serde-1", "arbitrary-1", "bytemuck-1", "rand-0_8", "rand-0_9", "postcard-experimental-1", "defmt-1"]
 std = ["alloc"]
 alloc = ["rand-0_8?/alloc", "rand-0_9?/alloc"]
 derive = ["dep:linearize-derive"]
@@ -23,6 +23,7 @@ bytemuck-1 = ["dep:bytemuck-1"]
 rand-0_8 = ["dep:rand-0_8"]
 rand-0_9 = ["dep:rand-0_9"]
 postcard-experimental-1 = ["dep:postcard-1"]
+defmt-1 = ["dep:defmt-1"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -36,6 +37,7 @@ bytemuck-1 = { package = "bytemuck", version = "1.9", default-features = false, 
 rand-0_8 = { package = "rand", version = "0.8.3", default-features = false, optional = true }
 rand-0_9 = { package = "rand", version = "0.9", default-features = false, optional = true }
 postcard-1 = { package = "postcard", version = "1", default-features = false, features = ["experimental-derive"], optional = true }
+defmt-1 = { package = "defmt", version = "1", default-features = false, optional = true }
 
 [build-dependencies]
 version_check = "0.9.5"

--- a/linearize/src/foreign.rs
+++ b/linearize/src/foreign.rs
@@ -2,6 +2,8 @@
 mod arbitrary_1;
 #[cfg(feature = "bytemuck-1")]
 mod bytemuck_1;
+#[cfg(feature = "defmt-1")]
+mod defmt_1;
 #[cfg(feature = "postcard-experimental-1")]
 mod postcard_1;
 #[cfg(feature = "rand-0_8")]

--- a/linearize/src/foreign.rs
+++ b/linearize/src/foreign.rs
@@ -2,6 +2,8 @@
 mod arbitrary_1;
 #[cfg(feature = "bytemuck-1")]
 mod bytemuck_1;
+#[cfg(feature = "postcard-experimental-1")]
+mod postcard_1;
 #[cfg(feature = "rand-0_8")]
 mod rand_0_8;
 #[cfg(feature = "rand-0_9")]

--- a/linearize/src/foreign/defmt_1.rs
+++ b/linearize/src/foreign/defmt_1.rs
@@ -1,0 +1,34 @@
+use {
+    crate::{Linearize, StaticCopyMap, StaticMap},
+    core::ops::Deref,
+    defmt_1 as defmt,
+};
+
+impl<L, T> defmt::Format for StaticMap<L, T>
+where
+    L: Linearize + defmt::Format,
+    T: defmt::Format,
+{
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(fmt, "{{");
+        let mut first = true;
+        for (k, v) in self {
+            if !first {
+                defmt::write!(fmt, ", ");
+            }
+            first = false;
+            defmt::write!(fmt, "{}: {}", k, v);
+        }
+        defmt::write!(fmt, "}}");
+    }
+}
+
+impl<L, T> defmt::Format for StaticCopyMap<L, T>
+where
+    L: Linearize + defmt::Format,
+    T: defmt::Format + Copy,
+{
+    fn format(&self, fmt: defmt::Formatter) {
+        self.deref().format(fmt);
+    }
+}

--- a/linearize/src/foreign/postcard_1.rs
+++ b/linearize/src/foreign/postcard_1.rs
@@ -1,0 +1,30 @@
+//! Implement the [`MaxSize`] trait from [`postcard_1`] for [`StaticMap`] and [`StaticCopyMap`].
+//!
+//! The table below shows how the serialization impls correspond to postcard's serializer and max size calculation.
+//! | serde impl                | postcard serializer        | max bytes                        |
+//! |---------------------------|----------------------------|----------------------------------|
+//! | serialize_map(len)        | try_push_varint_usize(len) | usize::POSTCARD_MAX_SIZE         |
+//! | serialize_key(&k) * len   | k.serialize()              | L::POSTCARD_MAX_SIZE * L::LENGTH |
+//! | serialize_value(&v) * len | v.serialize()              | T::POSTCARD_MAX_SIZE * L::LENGTH |
+
+use {
+    crate::{Linearize, StaticCopyMap, StaticMap},
+    postcard_1::experimental::max_size::MaxSize,
+};
+
+impl<L, T> MaxSize for StaticMap<L, T>
+where
+    L: Linearize + MaxSize,
+    T: MaxSize,
+{
+    const POSTCARD_MAX_SIZE: usize =
+        usize::POSTCARD_MAX_SIZE + L::LENGTH * (L::POSTCARD_MAX_SIZE + T::POSTCARD_MAX_SIZE);
+}
+
+impl<L, T> MaxSize for StaticCopyMap<L, T>
+where
+    L: Linearize + MaxSize,
+    T: MaxSize + Copy,
+{
+    const POSTCARD_MAX_SIZE: usize = <StaticMap<L, T>>::POSTCARD_MAX_SIZE;
+}

--- a/linearize/src/lib.rs
+++ b/linearize/src/lib.rs
@@ -69,6 +69,7 @@
 //! - `bytemuck-1`: Implements `NoUninit`, `Zeroable`, and `AnyBitPattern` from bytemuck 1.x for the map types.
 //! - `rand-0_8`: Implements various distributions from rand 0.8.x for the map types.
 //! - `rand-0_9`: Implements various distributions from rand 0.9.x for the map types.
+//! - `postcard-experimental-1`: Implements `MaxSize` from postcard 1.x for the map types.
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/linearize/src/lib.rs
+++ b/linearize/src/lib.rs
@@ -70,6 +70,7 @@
 //! - `rand-0_8`: Implements various distributions from rand 0.8.x for the map types.
 //! - `rand-0_9`: Implements various distributions from rand 0.9.x for the map types.
 //! - `postcard-experimental-1`: Implements `MaxSize` from postcard 1.x for the map types.
+//! - `defmt-1`: Implements `Format` from defmt 1.x for the map types.
 
 #[cfg(feature = "alloc")]
 extern crate alloc;


### PR DESCRIPTION
This PR adds two derives for `Static[Copy]Map`, gated by feature flags:

1. `postcard::MaxSize` - This is great for using `StaticMap` in `no_std` contexts over a wire, allows you to ensure at compile time that all your statically allocated buffers are correctly sized to fit the maximum size your type can be. Note, don't let the experimental fool you, I use it in production to great effect.

2. `defmt::Format` - Also great for no_std, allows seeing StaticMaps in logs that are effeciently sent from an embedded target and with _deferred formatting_ on the host.

Awesome library btw, I'm surprised it hasn't gotten more spotlight