### PR TITLE
improve `Send` and `Sync` impls for `StaticMap`s

### DIFF
--- a/linearize/src/copy_map.rs
+++ b/linearize/src/copy_map.rs
@@ -30,6 +30,42 @@ where
     L: Linearize + ?Sized,
     T: Copy;
 
+/// This custom implementation is guaranteed to always match the exact compiler generated
+/// [Send] implementation thanks to the safety requirement
+/// that `<L as Linearize>::CopyStorage<T>` is always just `[T;N]` for some `N`.
+///
+/// But in some generic contexts (when generic over `L` but with `T : Send`)
+/// the compiler cannot tell that `<L as Linearize>::CopyStorage<T> : Send` because it
+/// doesn't know that `<L as Linearize>::CopyStorage<T>` must be `[T;N]`.
+///
+/// This is necessary for the exact same reason why [StaticCopyMap] exists,
+/// but no one wants a `StaticSendMap` or worse `StaticSendSyncCopyMap`,
+/// and thankfully this can be avoided thanks to this manual implementation.
+unsafe impl<L, T> Send for StaticCopyMap<L, T>
+where
+    L: Linearize + ?Sized,
+    T: Send + Copy,
+{
+}
+
+/// This custom implementation is guaranteed to always match the exact compiler generated
+/// [Sync] implementation thanks to the safety requirement
+/// that `<L as Linearize>::CopyStorage<T>` is always just `[T;N]` for some `N`.
+///
+/// But in some generic contexts (when generic over `L` but with `T : Sync`)
+/// the compiler cannot tell that `<L as Linearize>::CopyStorage<T> : Sync` because it
+/// doesn't know that `<L as Linearize>::CopyStorage<T>` must be `[T;N]`.
+///
+/// This is necessary for the exact same reason why [StaticCopyMap] exists,
+/// but no one wants a `StaticSyncMap` or worse `StaticSendSyncCopyMap`,
+/// and thankfully this can be avoided thanks to this manual implementation.
+unsafe impl<L, T> Sync for StaticCopyMap<L, T>
+where
+    L: Linearize + ?Sized,
+    T: Sync + Copy,
+{
+}
+
 impl<L, T> StaticCopyMap<L, T>
 where
     L: Linearize + ?Sized,

--- a/linearize/src/copy_map.rs
+++ b/linearize/src/copy_map.rs
@@ -14,6 +14,7 @@ use {
         mem,
         ops::{Deref, DerefMut, Index, IndexMut},
     },
+    std::panic::{RefUnwindSafe, UnwindSafe},
 };
 
 /// A copyable, array-backed map with complex keys.
@@ -30,17 +31,10 @@ where
     L: Linearize + ?Sized,
     T: Copy;
 
-/// This custom implementation is guaranteed to always match the exact compiler generated
-/// [Send] implementation thanks to the safety requirement
-/// that `<L as Linearize>::CopyStorage<T>` is always just `[T;N]` for some `N`.
-///
-/// But in some generic contexts (when generic over `L` but with `T : Send`)
-/// the compiler cannot tell that `<L as Linearize>::CopyStorage<T> : Send` because it
-/// doesn't know that `<L as Linearize>::CopyStorage<T>` must be `[T;N]`.
-///
-/// This is necessary for the exact same reason why [StaticCopyMap] exists,
-/// but no one wants a `StaticSendMap` or worse `StaticSendSyncCopyMap`,
-/// and thankfully this can be avoided thanks to this manual implementation.
+// This impl exists to work around the compiler adding an L: <L as Linearize>::CopyStorage<T>: Send bound.
+//
+// SAFETY:
+// see the impl on StaticMap
 unsafe impl<L, T> Send for StaticCopyMap<L, T>
 where
     L: Linearize + ?Sized,
@@ -48,21 +42,46 @@ where
 {
 }
 
-/// This custom implementation is guaranteed to always match the exact compiler generated
-/// [Sync] implementation thanks to the safety requirement
-/// that `<L as Linearize>::CopyStorage<T>` is always just `[T;N]` for some `N`.
-///
-/// But in some generic contexts (when generic over `L` but with `T : Sync`)
-/// the compiler cannot tell that `<L as Linearize>::CopyStorage<T> : Sync` because it
-/// doesn't know that `<L as Linearize>::CopyStorage<T>` must be `[T;N]`.
-///
-/// This is necessary for the exact same reason why [StaticCopyMap] exists,
-/// but no one wants a `StaticSyncMap` or worse `StaticSendSyncCopyMap`,
-/// and thankfully this can be avoided thanks to this manual implementation.
+// This impl exists to work around the compiler adding an L: <L as Linearize>::CopyStorage<T>: Sync bound.
+//
+// SAFETY:
+// see the impl on StaticMap
 unsafe impl<L, T> Sync for StaticCopyMap<L, T>
 where
     L: Linearize + ?Sized,
     T: Sync + Copy,
+{
+}
+
+// This impl exists to work around the compiler adding an <L as Linearize>::CopyStorage<T>: Unpin bound.
+//
+// SAFETY:
+// this is safe, but it is imortant to note that a written it still allows
+// StaticMap to be structurally pinning over its elements,
+// where an unconditional impl would not;
+// rational : see the Sync and Send impl
+impl<L, T> Unpin for StaticCopyMap<L, T>
+where
+    L: Linearize + ?Sized,
+    T: Unpin + Copy,
+{
+}
+
+// This impl exists to work around the compiler adding an <L as Linearize>::CopyStorage<T>: UnwindSafe bound.
+// rational : see the Sync and Send impl
+impl<L, T> UnwindSafe for StaticCopyMap<L, T>
+where
+    L: Linearize + ?Sized,
+    T: UnwindSafe + Copy,
+{
+}
+
+// This impl exists to work around the compiler adding an <L as Linearize>::CopyStorage<T>: RefUnwindSafe bound.
+// rational : see the Sync and Send impl
+impl<L, T> RefUnwindSafe for StaticCopyMap<L, T>
+where
+    L: Linearize + ?Sized,
+    T: RefUnwindSafe + Copy,
 {
 }
 

--- a/linearize/src/map.rs
+++ b/linearize/src/map.rs
@@ -181,6 +181,42 @@ pub struct StaticMap<L, T>(
 where
     L: Linearize + ?Sized;
 
+/// This custom implementation is guaranteed to always match the exact compiler generated
+/// [Send] implementation thanks to the safety requirement
+/// that `<L as Linearize>::Storage<T>` is always just `[T;N]` for some `N`.
+///
+/// But in some generic contexts (when generic over `L` but with `T : Send`)
+/// the compiler cannot tell that `<L as Linearize>::Storage<T> : Send` because it
+/// doesn't know that `<L as Linearize>::Storage<T>` must be `[T;N]`.
+///
+/// This is necessary for the exact same reason why [StaticCopyMap] exists,
+/// but no one wants a `StaticSendMap` or worse `StaticSendSyncCopyMap`,
+/// and thankfully this can be avoided thanks to this manual implementation.
+unsafe impl<L, T> Send for StaticMap<L, T>
+where
+    L: Linearize + ?Sized,
+    T: Send,
+{
+}
+
+/// This custom implementation is guaranteed to always match the exact compiler generated
+/// [Sync] implementation thanks to the safety requirement
+/// that `<L as Linearize>::Storage<T>` is always just `[T;N]` for some `N`.
+///
+/// But in some generic contexts (when generic over `L` but with `T : Sync`)
+/// the compiler cannot tell that `<L as Linearize>::Storage<T> : Sync` because it
+/// doesn't know that `<L as Linearize>::Storage<T>` must be `[T;N]`.
+///
+/// This is necessary for the exact same reason why [StaticCopyMap] exists,
+/// but no one wants a `StaticSyncMap` or worse `StaticSendSyncCopyMap`,
+/// and thankfully this can be avoided thanks to this manual implementation.
+unsafe impl<L, T> Sync for StaticMap<L, T>
+where
+    L: Linearize + ?Sized,
+    T: Sync,
+{
+}
+
 impl<L, T> StaticMap<L, T>
 where
     L: Linearize + ?Sized,

--- a/linearize/src/map.rs
+++ b/linearize/src/map.rs
@@ -15,6 +15,7 @@ use {
         mem,
         ops::{Deref, DerefMut, Index, IndexMut},
     },
+    std::panic::{RefUnwindSafe, UnwindSafe},
 };
 
 pub(crate) mod iters;
@@ -181,17 +182,19 @@ pub struct StaticMap<L, T>(
 where
     L: Linearize + ?Sized;
 
-/// This custom implementation is guaranteed to always match the exact compiler generated
-/// [Send] implementation thanks to the safety requirement
-/// that `<L as Linearize>::Storage<T>` is always just `[T;N]` for some `N`.
-///
-/// But in some generic contexts (when generic over `L` but with `T : Send`)
-/// the compiler cannot tell that `<L as Linearize>::Storage<T> : Send` because it
-/// doesn't know that `<L as Linearize>::Storage<T>` must be `[T;N]`.
-///
-/// This is necessary for the exact same reason why [StaticCopyMap] exists,
-/// but no one wants a `StaticSendMap` or worse `StaticSendSyncCopyMap`,
-/// and thankfully this can be avoided thanks to this manual implementation.
+// This impl exists to work around the compiler adding an L: <L as Linearize>::Storage<T>: Send bound.
+//
+// SAFETY:
+// - T is Send by the where clause.
+// - Therefore [T; N] is Send for all N.
+// - By the safety requirements of Linearize, L::Storage<T> = [T; L::LENGTH].
+// - Therefore L::Storage<T> is Send.
+// - StaticMap<L, T> has a single, public L::Storage<T> field and no Drop impl.
+// - Therefore, StaticMap<L, T> can be safely converted from and into
+//   L::Storage<T>.
+// - Therefore, StaticMap<L, T> could already be Sent by converting to
+//   L::Storage<T> at the time of the operation.
+// - Therefore, this impl does not add any Send capability.
 unsafe impl<L, T> Send for StaticMap<L, T>
 where
     L: Linearize + ?Sized,
@@ -199,21 +202,57 @@ where
 {
 }
 
-/// This custom implementation is guaranteed to always match the exact compiler generated
-/// [Sync] implementation thanks to the safety requirement
-/// that `<L as Linearize>::Storage<T>` is always just `[T;N]` for some `N`.
-///
-/// But in some generic contexts (when generic over `L` but with `T : Sync`)
-/// the compiler cannot tell that `<L as Linearize>::Storage<T> : Sync` because it
-/// doesn't know that `<L as Linearize>::Storage<T>` must be `[T;N]`.
-///
-/// This is necessary for the exact same reason why [StaticCopyMap] exists,
-/// but no one wants a `StaticSyncMap` or worse `StaticSendSyncCopyMap`,
-/// and thankfully this can be avoided thanks to this manual implementation.
+// This impl exists to work around the compiler adding an <L as Linearize>::Storage<T>: Sync bound.
+//
+// SAFETY:
+//
+// - T is Sync by the where clause.
+// - Therefore [T; N] is Sync for all N.
+// - By the safety requirements of Linearize, L::Storage<T> = [T; L::LENGTH].
+// - Therefore L::Storage<T> is Sync.
+// - Therefore &L::Storage<T> is Send.
+// - &StaticMap<L, T> can safely be created from &L::Storage<T> and converted to
+//   &L::Storage<T>.
+// - Therefore &StaticMap<L, T> could already be Sent by doing this conversion at the
+//   time of the operation.
+// - Therefore &StaticMap<L, T> is Send.
+// - Therefore StaticMap<L, T> is Sync.
 unsafe impl<L, T> Sync for StaticMap<L, T>
 where
     L: Linearize + ?Sized,
     T: Sync,
+{
+}
+
+// This impl exists to work around the compiler adding an <L as Linearize>::Storage<T>: Unpin bound.
+//
+// SAFETY:
+// this is safe, but it is imortant to note that a written it still allows
+// StaticMap to be structurally pinning over its elements,
+// where an unconditional impl would not.
+// rational : see the Sync and Send impl
+impl<L, T> Unpin for StaticMap<L, T>
+where
+    L: Linearize + ?Sized,
+    T: Unpin,
+{
+}
+
+// This impl exists to work around the compiler adding an <L as Linearize>::Storage<T>: UnwindSafe bound.
+// rational : see the Sync and Send impl
+impl<L, T> UnwindSafe for StaticMap<L, T>
+where
+    L: Linearize + ?Sized,
+    T: UnwindSafe,
+{
+}
+
+// This impl exists to work around the compiler adding an <L as Linearize>::Storage<T>: RefUnwindSafe bound.
+// rational : see the Sync and Send impl
+impl<L, T> RefUnwindSafe for StaticMap<L, T>
+where
+    L: Linearize + ?Sized,
+    T: RefUnwindSafe,
 {
 }
 


### PR DESCRIPTION
the compiler generated `Send` and `Sync` impls for `StaticMap` are overly restrictive and can cause issues in generic contexts.
these new manual implementation fixes the issue.